### PR TITLE
Launch the initial function once when page is reflashed.

### DIFF
--- a/common.js
+++ b/common.js
@@ -189,9 +189,8 @@ function listener() {
 }
 
 
-
 var timeout = null;
-document.addEventListener("DOMSubtreeModified", function() {
+function launch() {
     if (timeout) {
         clearTimeout(timeout);
     }
@@ -200,4 +199,11 @@ document.addEventListener("DOMSubtreeModified", function() {
     } else if ($(".downloadlink").length == 0) {
         timeout = setTimeout(listener, 2000);
     }
-}, false);
+}
+launch();
+
+var observer = new MutationObserver(launch);
+observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true
+});


### PR DESCRIPTION
This would fix the extension in CUHK cusis, where the whole page, instead of some of the elements, would be mutated on button fire.
And I also change the listener to MutationObserver. I have no clue if it works in CUHKSZ's system. Please test it before merging.